### PR TITLE
Use go version specified in go.mod

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,9 +13,9 @@ jobs:
       uses: actions/checkout@v4
     
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
-        go-version: 1.20.8
+        go-version-file: 'go.mod'
     
     - name: Check formatting
       run: |
@@ -34,9 +34,9 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
-        go-version: 1.20.8
+        go-version-file: 'go.mod'
 
     - name: Vet
       run: go vet ./...
@@ -52,9 +52,9 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
-        go-version: 1.20.8
+        go-version-file: 'go.mod'
 
     - name: Test
       run: go test ./...


### PR DESCRIPTION
Changes CI workflow `test` to use go version as specified in `go.mod` file instead of hardcoding to specific version